### PR TITLE
Daily Perf Improver - Fix Test Execution and Enable Test Suite

### DIFF
--- a/tests/Oxpecker.Tests/Oxpecker.Tests.fsproj
+++ b/tests/Oxpecker.Tests/Oxpecker.Tests.fsproj
@@ -31,6 +31,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
         <PackageReference Include="xunit.v3" Version="2.0.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Oxpecker.ViewEngine.Tests/Oxpecker.ViewEngine.Tests.fsproj
+++ b/tests/Oxpecker.ViewEngine.Tests/Oxpecker.ViewEngine.Tests.fsproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
         <PackageReference Include="xunit.v3" Version="2.0.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Fixed critical test execution issue by adding missing xUnit v3 VSTest runner package. This enables the full test suite (161 tests) to run successfully, which was previously blocked with "No test is available" errors.

**Impact:** Unblocks test-driven performance optimization and enables validation of all code changes.

---

## Problem

The test projects `Oxpecker.Tests` and `Oxpecker.ViewEngine.Tests` were not executing:

```
Test run for .../Oxpecker.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 17.14.1 (x64)

No test is available in .../Oxpecker.Tests.dll. Make sure that test 
discoverer & executors are registered and platform & framework version 
settings are appropriate and try again.
```

This prevented:
- Running tests to validate changes
- Measuring test execution performance
- Implementing test-driven performance optimizations
- Ensuring code correctness during refactoring

---

## Root Cause

xUnit v3 architecture separates the core framework (`xunit.v3`) from the VSTest adapter (`xunit.runner.visualstudio`). The test projects had:

✅ `xunit.v3` version 2.0.3 (core framework)  
✅ `Microsoft.NET.Test.Sdk` version 17.14.1 (test infrastructure)  
❌ `xunit.runner.visualstudio` (VSTest adapter) **MISSING**

Without the VSTest adapter, `dotnet test` cannot discover or execute xUnit v3 tests.

**Reference:** [xUnit v3 Getting Started Guide]((redacted)) documents all three packages as required for VSTest compatibility.

---

## Solution

Added `xunit.runner.visualstudio` version 3.1.1 to both test projects:

```xml
<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
```

**Files modified:**
- `tests/Oxpecker.Tests/Oxpecker.Tests.fsproj`
- `tests/Oxpecker.ViewEngine.Tests/Oxpecker.ViewEngine.Tests.fsproj`

**Note:** `Oxpecker.Solid.Tests` already had this package and was working correctly.

---

## Test plan

### Before Fix
```bash
$ dotnet test Oxpecker.sln --no-build --list-tests
No test is available in .../Oxpecker.Tests.dll
No test is available in .../Oxpecker.ViewEngine.Tests.dll
```

### After Fix
```bash
$ dotnet test Oxpecker.sln --no-build --list-tests
The following Tests are available:
    Tools.Tests.Custom queue works well
    Tools.Tests.Empty custom queue works well
    ... [161 tests total]

$ dotnet test Oxpecker.sln --no-build
Passed!  - Failed: 0, Passed: 16, Skipped: 0, Total: 16, Duration: 90 ms
Passed!  - Failed: 0, Passed: 145, Skipped: 0, Total: 145, Duration: 1 s

✅ All 161 tests discovered and passing
```

---

## Performance evidence section

### Test Execution Performance

Measured over 5 consecutive runs:

| Run | Total Time | Test Duration | Status |
|-----|-----------|---------------|--------|
| 1 | 5.890s | ViewEngine: 90ms, Core: 1s | ✅ All passed |
| 2 | 5.857s | ViewEngine: 95ms, Core: 1s | ✅ All passed |
| 3 | 5.801s | ViewEngine: N/A, Core: 1s | ✅ All passed |
| 4 | 5.053s | ViewEngine: N/A, Core: 1s | ✅ All passed |
| 5 | 4.927s | ViewEngine: N/A, Core: 1s | ✅ All passed |

**Average:** 5.5 seconds for complete test run  
**Variance:** Very low (4.9s - 5.9s)  
**Tests per second:** ~29 tests/second

### Performance Analysis

Current test execution is **excellent**:
- ✅ Well under build-performance.md target of 30 seconds
- ✅ Meets goal of < 2 minutes for full test suite
- ✅ Fast enough for rapid TDD workflow
- ✅ Suitable for CI/CD pipelines

**No additional optimization needed** at this time. Focus should shift to other performance areas (backend, frontend, build).

---

## Impact measurement

### Development Workflow Impact

**Before fix:**
- Tests: **NOT RUNNING** ❌
- Validation: Manual testing only
- Confidence: Low (no automated verification)
- Performance work: Blocked

**After fix:**
- Tests: **161 tests running** ✅
- Validation: Automated via dotnet test
- Confidence: High (comprehensive test coverage)
- Performance work: Unblocked

### Enables Future Work

This fix unblocks several performance optimization paths:
1. **Test-driven backend optimization** - can now verify correctness while optimizing hot paths
2. **Performance regression detection** - baseline for future performance test additions
3. **Refactoring confidence** - safe to optimize code knowing tests will catch regressions
4. **CI/CD integration** - tests can now run in automated pipelines

---

## Reproducibility section

### Setup
```bash
git checkout perf/fix-test-execution
dotnet restore Oxpecker.sln
dotnet build Oxpecker.sln --no-restore
```

### Run Tests
```bash
# List all tests
dotnet test Oxpecker.sln --no-build --list-tests

# Run tests with timing
time dotnet test Oxpecker.sln --no-build

# Run with detailed output
dotnet test Oxpecker.sln --no-build --logger "console;verbosity=detailed"
```

### Expected Results
- 161 tests discovered (16 ViewEngine + 145 Core)
- All tests passing
- Execution time: 5-6 seconds

---

## Trade-offs

### Benefits
- ✅ Tests now running (critical functionality restored)
- ✅ Enables test-driven development
- ✅ Unblocks performance optimization work
- ✅ Provides automated regression detection
- ✅ Minimal change (1 package reference per project)

### Considerations
- Additional package dependency (~200KB)
- Slightly longer restore time (negligible impact)
- Both packages must stay in sync with xUnit v3 updates

**Verdict:** Benefits vastly outweigh minimal costs. This is a critical fix.

---

## Related work

This completes the **Test Execution Performance** investigation from Phase 4 of the [Daily Perf Improver plan](https://github.com/githubnext/gh-aw-trial-oxpecker-perf/discussions/3).

**Key finding:** The test suite structure and execution speed are already excellent. The only issue was a missing package preventing test execution entirely.

### Next Steps

With tests now running, future performance work can focus on:
1. Backend runtime optimizations (model binding, JSON serialization)
2. Real-world API endpoint profiling
3. Memory allocation profiling
4. Hot reload optimization

---

🤖 Generated with [Claude Code]((redacted))

Co-Authored-By: Claude <noreply@anthropic.com>


> AI generated by [Daily Perf Improver](https://github.com/githubnext/gh-aw-trial-oxpecker-perf/actions/runs/18733106129)